### PR TITLE
🌱: WebViewで発生するエラーの検証コードを追加

### DIFF
--- a/ErrorHandling/.script/http-server.js
+++ b/ErrorHandling/.script/http-server.js
@@ -1,0 +1,12 @@
+const http = require('http');
+http
+  .createServer((req, res) => {
+    const path = req.url;
+    const parsed = parseInt(path.replace('/', ''));
+    const statusCode = isNaN(parsed) ? 200 : parsed;
+    res.writeHead(statusCode, {'Content-Type': 'text/html'});
+    res.end(
+      `<html lang="ja"><meta charset="utf-8"/><body>ステータスコードは${statusCode}です。<br><img src="http://localhost:3021" alt="img1"><img src="http://localhost:3000/400" alt="img2"></body></html>`,
+    );
+  })
+  .listen(3000, () => console.log('Server http://localhost:3000'));

--- a/ErrorHandling/.script/http-server.js
+++ b/ErrorHandling/.script/http-server.js
@@ -1,9 +1,17 @@
 const http = require('http');
 http
-  .createServer((req, res) => {
+  .createServer(async (req, res) => {
     const path = req.url;
     const parsed = parseInt(path.replace('/', ''));
     const statusCode = isNaN(parsed) ? 200 : parsed;
+
+    // タイムアウトの検証でSleepしたい場合はコメントを解除してください
+    // await new Promise((resolve, reject) => {
+    //   setTimeout(() => {
+    //     resolve();
+    //   }, 1200000);
+    // });
+
     res.writeHead(statusCode, {'Content-Type': 'text/html'});
     res.end(
       `<html lang="ja"><meta charset="utf-8"/><body>ステータスコードは${statusCode}です。<br><img src="http://localhost:3021" alt="img1"><img src="http://localhost:3000/400" alt="img2"></body></html>`,

--- a/ErrorHandling/README.md
+++ b/ErrorHandling/README.md
@@ -2,6 +2,8 @@
 
 React Nativeを使用したアプリのエラーハンドリングについて検証するプロジェクトです。
 
+## グローバルエラーハンドリング
+
 以下のケースにおいて、捕捉されていないエラーをハンドリングして、Firebase Crashlyticsにエラーログを送信できるかを検証しています。
 
 * React Componentで発生したエラー
@@ -28,6 +30,20 @@ React Nativeを使用したアプリのエラーハンドリングについて�
 
 上記方法で、エラーを捕捉できることを検証していますが、 現在コミットしているソースコードでは、独自でグローバルなエラーハンドリングを実施せず、全てFirebase Crashlytics側で処理する方法としています。
 ※ 上記方法の動作を確認したい場合は、必要に応じて該当箇所のコメントアウトを解除してください。
+
+## WebViewで発生するエラーのハンドリング
+
+以下のケースにおいて、エラーをハンドリングしてFirebase Crashlyticsにエラーログを送信できるかを検証しています。
+
+* WebViewで表示するページを取得する際に、ステータスコード400以上が返却される場合
+* ネットワークエラーなどによりWebViewで表示するページにアクセスできない場合
+
+React Native WebViewの`onError`、`onHttpError`属性を使用してエラーをハンドリングします。
+
+| 属性 | 捕捉できるエラー |
+|:----|:----|
+| onHttpError | WebViewで表示するページから、ステータスコード400以上が返却される場合 |
+| onError | ネットワークエラーなどによりWebViewで表示するページにアクセスできない場合 |
     
 ## アプリの実行
 
@@ -41,7 +57,12 @@ npm run android -- --variant Release
 npm run ios -- --configuration Release
 ```
 
-実行後に表示されるページで、エラーを発生させるとアプリがクラッシュしてエラーログがFirebase Crashlyticsに送信されます。
+WebViewでコンテンツを表示するために、HttpServerを起動します。
+```bash
+npm run http-server
+```
+
+実行後に表示されるページでエラーを発生させると、アプリがクラッシュしてエラーログがFirebase Crashlyticsに送信されます。（WebViewとHTTP API通信については、個別にエラーハンドリングしているのでクラッシュしません。）
 Firebase Crashlyticsにログが送信されるタイミングは、アプリがクラッシュした後に、再度アプリを起動した時になります。
 
 なお、ReleaseモードではなくDebugモードでもアプリは動作しますが、Debugモードではエラー時にReact NativeがLogBoxにエラーログを表示する影響で、Firebase Crashlyticsにはログが送信されません。

--- a/ErrorHandling/README.md
+++ b/ErrorHandling/README.md
@@ -57,11 +57,6 @@ npm run android -- --variant Release
 npm run ios -- --configuration Release
 ```
 
-WebViewでコンテンツを表示するために、HttpServerを起動します。
-```bash
-npm run http-server
-```
-
 実行後に表示されるページでエラーを発生させると、アプリがクラッシュしてエラーログがFirebase Crashlyticsに送信されます。（WebViewとHTTP API通信については、個別にエラーハンドリングしているのでクラッシュしません。）
 Firebase Crashlyticsにログが送信されるタイミングは、アプリがクラッシュした後に、再度アプリを起動した時になります。
 
@@ -73,6 +68,13 @@ iPhoneでアプリを実行するには、以下の手順が必要です。
 * Firebase Consoleで、Bundle Identifierに個人のサフィックスを追加してアプリを追加する
 * 追加したアプリでCrashlyticsを有効にする
 * `GoogleService-Info.plist`をダウンロードして、`ios`ディレクトリに格納する
+
+## WebViewで表示するコンテンツサーバの起動
+
+WebViewでコンテンツを表示するために、HttpServerを起動します。
+```bash
+npm run http-server
+```
 
 ## Firebase Crashlyticsのコンソールに表示されているスタックトレースとソースコードのマッピング
 

--- a/ErrorHandling/android/app/src/main/AndroidManifest.xml
+++ b/ErrorHandling/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
     android:theme="@style/AppTheme"
+    android:usesCleartextTraffic="true"
   >
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="YOUR-APP-URL-HERE"/>

--- a/ErrorHandling/android/app/src/main/AndroidManifest.xml
+++ b/ErrorHandling/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 
   <uses-permission android:name="android.permission.INTERNET"/>
 
+  <!-- ReleaseモードでもWebViewからページ取得するサーバにHTTP通信でアクセスできるようにusesCleartextTrafficをtrueにする -->
   <application
     android:name=".MainApplication"
     android:label="@string/app_name"

--- a/ErrorHandling/ios/Podfile.lock
+++ b/ErrorHandling/ios/Podfile.lock
@@ -319,6 +319,8 @@ PODS:
   - React-jsinspector (0.63.4)
   - react-native-safe-area-context (3.2.0):
     - React-Core
+  - react-native-webview (11.6.5):
+    - React-Core
   - React-RCTActionSheet (0.63.4):
     - React-Core/RCTActionSheetHeaders (= 0.63.4)
   - React-RCTAnimation (0.63.4):
@@ -496,6 +498,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -606,6 +609,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -715,6 +720,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
   react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
+  react-native-webview: 2e8fe70dc32b50d3231c23043f8e8b5a5525d346
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/ErrorHandling/package-lock.json
+++ b/ErrorHandling/package-lock.json
@@ -24,7 +24,8 @@
         "react-native-safe-area-context": "3.2.0",
         "react-native-screens": "~3.0.0",
         "react-native-unimodules": "~0.13.3",
-        "react-native-web": "~0.13.12"
+        "react-native-web": "~0.13.12",
+        "react-native-webview": "^11.6.5"
       },
       "devDependencies": {
         "@babel/core": "~7.9.0",
@@ -16889,6 +16890,26 @@
         "ua-parser-js": "^0.7.18"
       }
     },
+    "node_modules/react-native-webview": {
+      "version": "11.6.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.5.tgz",
+      "integrity": "sha512-5U+hI8snkCrFeDy+bUTszwhzcJIenaaOy3ubhY77HZq7R0pFIZzRYWkT0YXe1ymRYW9mSU96nr6S0AVDk8qkMw==",
+      "dependencies": {
+        "escape-string-regexp": "2.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60 <=0.64"
+      }
+    },
+    "node_modules/react-native-webview/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/react-native/node_modules/@jest/types": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
@@ -33311,6 +33332,22 @@
             "setimmediate": "^1.0.5",
             "ua-parser-js": "^0.7.18"
           }
+        }
+      }
+    },
+    "react-native-webview": {
+      "version": "11.6.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.5.tgz",
+      "integrity": "sha512-5U+hI8snkCrFeDy+bUTszwhzcJIenaaOy3ubhY77HZq7R0pFIZzRYWkT0YXe1ymRYW9mSU96nr6S0AVDk8qkMw==",
+      "requires": {
+        "escape-string-regexp": "2.0.0",
+        "invariant": "2.2.4"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         }
       }
     },

--- a/ErrorHandling/package-lock.json
+++ b/ErrorHandling/package-lock.json
@@ -25,7 +25,7 @@
         "react-native-screens": "~3.0.0",
         "react-native-unimodules": "~0.13.3",
         "react-native-web": "~0.13.12",
-        "react-native-webview": "^11.6.5"
+        "react-native-webview": "11.2.3"
       },
       "devDependencies": {
         "@babel/core": "~7.9.0",
@@ -16891,15 +16891,15 @@
       }
     },
     "node_modules/react-native-webview": {
-      "version": "11.6.5",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.5.tgz",
-      "integrity": "sha512-5U+hI8snkCrFeDy+bUTszwhzcJIenaaOy3ubhY77HZq7R0pFIZzRYWkT0YXe1ymRYW9mSU96nr6S0AVDk8qkMw==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.2.3.tgz",
+      "integrity": "sha512-r/K+Lf/O5aij72gRndMX2qsyQ/WLtDPiO75SS57y6JjqSKxedGASVL9Jwl1TM7fCXqUq8dgiwik/LuBHbJXAEg==",
       "dependencies": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"
       },
       "peerDependencies": {
-        "react-native": ">=0.60 <=0.64"
+        "react-native": ">=0.60 <0.64"
       }
     },
     "node_modules/react-native-webview/node_modules/escape-string-regexp": {
@@ -33336,9 +33336,9 @@
       }
     },
     "react-native-webview": {
-      "version": "11.6.5",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.5.tgz",
-      "integrity": "sha512-5U+hI8snkCrFeDy+bUTszwhzcJIenaaOy3ubhY77HZq7R0pFIZzRYWkT0YXe1ymRYW9mSU96nr6S0AVDk8qkMw==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.2.3.tgz",
+      "integrity": "sha512-r/K+Lf/O5aij72gRndMX2qsyQ/WLtDPiO75SS57y6JjqSKxedGASVL9Jwl1TM7fCXqUq8dgiwik/LuBHbJXAEg==",
       "requires": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"

--- a/ErrorHandling/package.json
+++ b/ErrorHandling/package.json
@@ -42,7 +42,7 @@
     "react-native-screens": "~3.0.0",
     "react-native-unimodules": "~0.13.3",
     "react-native-web": "~0.13.12",
-    "react-native-webview": "^11.6.5"
+    "react-native-webview": "11.2.3"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/ErrorHandling/package.json
+++ b/ErrorHandling/package.json
@@ -18,7 +18,8 @@
     "bundle:android": "mkdirp ./generated && react-native bundle --dev false --sourcemap-output ./generated/index.android.bundle.map --entry-file index.js --bundle-output ./generated/index.android.bundle --platform android",
     "bundle:ios": "mkdirp ./generated && react-native bundle --dev false --sourcemap-output ./generated/index.ios.bundle.map --entry-file index.js --bundle-output ./generated/index.ios.bundle --platform ios",
     "symbolicate:android": "npx metro-symbolicate ./generated/index.android.bundle.map",
-    "symbolicate:ios": "npx metro-symbolicate ./generated/index.ios.bundle.map"
+    "symbolicate:ios": "npx metro-symbolicate ./generated/index.ios.bundle.map",
+    "http-server": "node .script/http-server.js"
   },
   "dependencies": {
     "@react-native-community/masked-view": "0.1.10",
@@ -40,7 +41,8 @@
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
     "react-native-unimodules": "~0.13.3",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "~0.13.12",
+    "react-native-webview": "^11.6.5"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/ErrorHandling/src/navigation/RootStackNav.tsx
+++ b/ErrorHandling/src/navigation/RootStackNav.tsx
@@ -9,6 +9,7 @@ import {
   ErrorInUseEffectSyncProcess,
 } from '../screens';
 import {ErrorInUseEffectAsyncProcess} from '../screens/ErrorInUseEffectAsyncProcess';
+import {ErrorInWebView} from '../screens/ErrorInWebView';
 
 const nav = createStackNavigator();
 export const RootStackNav: React.FC = () => {
@@ -20,6 +21,7 @@ export const RootStackNav: React.FC = () => {
       <nav.Screen name={ErrorInUseEffectAsyncProcess.ScreenName} component={ErrorInUseEffectAsyncProcess.Screen} />
       <nav.Screen name={ErrorInReactComponent.ScreenName} component={ErrorInReactComponent.Screen} />
       <nav.Screen name={ErrorInNativeModule.ScreenName} component={ErrorInNativeModule.Screen} />
+      <nav.Screen name={ErrorInWebView.ScreenName} component={ErrorInWebView.Screen} />
     </nav.Navigator>
   );
 };

--- a/ErrorHandling/src/screens/ErrorCase.tsx
+++ b/ErrorHandling/src/screens/ErrorCase.tsx
@@ -8,6 +8,7 @@ import {ErrorInNativeModule} from './ErrorInNativeModules';
 import {ErrorInReactComponent} from './ErrorInReactComponent';
 import {ErrorInUseEffectAsyncProcess} from './ErrorInUseEffectAsyncProcess';
 import {ErrorInUseEffectSyncProcess} from './ErrorInUseEffectSyncProcess';
+import {ErrorInWebView} from './ErrorInWebView';
 
 const ScreenName = 'ErrorCase';
 const Screen = () => {
@@ -25,6 +26,7 @@ const Screen = () => {
       />
       <Button onPress={() => navigation.navigate(ErrorInReactComponent.ScreenName)} title="ReactComponentでエラー" />
       <Button onPress={() => navigation.navigate(ErrorInNativeModule.ScreenName)} title="Native Modulesでエラー" />
+      <Button onPress={() => navigation.navigate(ErrorInWebView.ScreenName)} title="WebViewでエラー" />
     </View>
   );
 };

--- a/ErrorHandling/src/screens/ErrorInWebView.tsx
+++ b/ErrorHandling/src/screens/ErrorInWebView.tsx
@@ -1,0 +1,121 @@
+import crashlytics from '@react-native-firebase/crashlytics';
+import React, {useState} from 'react';
+import {StyleSheet, View, Text, Platform} from 'react-native';
+import {Button, Input} from 'react-native-elements';
+import WebView from 'react-native-webview';
+import {WebViewError, WebViewHttpError} from 'react-native-webview/lib/WebViewTypes';
+
+const baseHost = Platform.select({
+  ios: 'localhost',
+  android: '10.0.2.2',
+});
+
+const ScreenName = 'ErrorInWebView';
+const Screen = () => {
+  const [statusCode, setStatusCode] = useState<string>('200');
+  const [host, setHost] = useState<string>(baseHost ?? 'localhost');
+  const [statusCodeInputValue, setStatusCodeInputValue] = useState<string>();
+  const [ipInputValue, setIpInputValue] = useState<string>();
+  const [httpError, setHttpError] = useState<WebViewHttpError | undefined>(undefined);
+  const [error, setError] = useState<WebViewError | undefined>(undefined);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.webviewContainer}>
+        {httpError ? (
+          <View>
+            <Text>http error</Text>
+            <Text>{httpError.title}</Text>
+            <Text>{httpError.statusCode}</Text>
+            <Text>{httpError.description}</Text>
+          </View>
+        ) : error ? (
+          <View>
+            <Text>error</Text>
+            <Text>{error.title}</Text>
+            <Text>{error.code}</Text>
+            <Text>{error.description}</Text>
+          </View>
+        ) : (
+          <WebView
+            source={{uri: `http://${host}:3000/${statusCode}`}}
+            onError={(event) => {
+              setHttpError(undefined);
+              setError(event.nativeEvent);
+              crashlytics().recordError(
+                new Error(
+                  `Error occurred in webview. code=[${event.nativeEvent.code}]. description=[${event.nativeEvent.description}]`,
+                ),
+                'WebViewError',
+              );
+            }}
+            onHttpError={(event) => {
+              setHttpError(event.nativeEvent);
+              setError(undefined);
+              crashlytics().recordError(
+                new Error(
+                  `HttpError occurred in webview. statusCode=[${event.nativeEvent.statusCode}]. description=[${event.nativeEvent.description}]`,
+                ),
+                'WebViewHttpError',
+              );
+            }}
+          />
+        )}
+      </View>
+      <View style={styles.textInputContainer}>
+        <Input
+          placeholder="返却するステータスコードを入力してください"
+          style={styles.textInput}
+          value={statusCodeInputValue}
+          onChangeText={(value) => setStatusCodeInputValue(value)}
+        />
+      </View>
+      <View style={styles.textInputContainer}>
+        <Input
+          placeholder="サーバのIP（デフォルトは、localhost or 10.0.2.2）"
+          style={styles.textInput}
+          value={ipInputValue}
+          onChangeText={(value) => setIpInputValue(value)}
+        />
+      </View>
+      <View style={styles.actionContainer}>
+        <Button
+          onPress={() => {
+            setHttpError(undefined);
+            setError(undefined);
+            setStatusCode(statusCodeInputValue ?? '200');
+            setHost(ipInputValue ?? baseHost ?? 'localhost');
+          }}
+          title="WebView再表示"
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  webviewContainer: {
+    flex: 6,
+    width: '100%',
+  },
+  textInputContainer: {
+    flex: 1,
+    marginTop: 10,
+  },
+  textInput: {
+    fontSize: 12,
+  },
+  actionContainer: {
+    flex: 1,
+    marginTop: 10,
+    alignItems: 'center',
+  },
+});
+
+export const ErrorInWebView = {
+  Screen,
+  ScreenName,
+};

--- a/ErrorHandling/src/screens/ErrorInWebView.tsx
+++ b/ErrorHandling/src/screens/ErrorInWebView.tsx
@@ -21,46 +21,46 @@ const Screen = () => {
 
   return (
     <View style={styles.container}>
+      {httpError && (
+        <View style={styles.errorContainer}>
+          <Text>http error</Text>
+          <Text>{httpError.title}</Text>
+          <Text>{httpError.statusCode}</Text>
+          <Text>{httpError.description}</Text>
+        </View>
+      )}
+      {error && (
+        <View style={styles.errorContainer}>
+          <Text>error</Text>
+          <Text>{error.title}</Text>
+          <Text>{error.code}</Text>
+          <Text>{error.description}</Text>
+        </View>
+      )}
       <View style={styles.webviewContainer}>
-        {httpError ? (
-          <View>
-            <Text>http error</Text>
-            <Text>{httpError.title}</Text>
-            <Text>{httpError.statusCode}</Text>
-            <Text>{httpError.description}</Text>
-          </View>
-        ) : error ? (
-          <View>
-            <Text>error</Text>
-            <Text>{error.title}</Text>
-            <Text>{error.code}</Text>
-            <Text>{error.description}</Text>
-          </View>
-        ) : (
-          <WebView
-            source={{uri: `http://${host}:3000/${statusCode}`}}
-            onError={(event) => {
-              setHttpError(undefined);
-              setError(event.nativeEvent);
-              crashlytics().recordError(
-                new Error(
-                  `Error occurred in webview. code=[${event.nativeEvent.code}]. description=[${event.nativeEvent.description}]`,
-                ),
-                'WebViewError',
-              );
-            }}
-            onHttpError={(event) => {
-              setHttpError(event.nativeEvent);
-              setError(undefined);
-              crashlytics().recordError(
-                new Error(
-                  `HttpError occurred in webview. statusCode=[${event.nativeEvent.statusCode}]. description=[${event.nativeEvent.description}]`,
-                ),
-                'WebViewHttpError',
-              );
-            }}
-          />
-        )}
+        <WebView
+          source={{uri: `http://${host}:3000/${statusCode}`}}
+          onError={(event) => {
+            setHttpError(undefined);
+            setError(event.nativeEvent);
+            crashlytics().recordError(
+              new Error(
+                `Error occurred in webview. code=[${event.nativeEvent.code}]. description=[${event.nativeEvent.description}]`,
+              ),
+              'WebViewError',
+            );
+          }}
+          onHttpError={(event) => {
+            setHttpError(event.nativeEvent);
+            setError(undefined);
+            crashlytics().recordError(
+              new Error(
+                `HttpError occurred in webview. statusCode=[${event.nativeEvent.statusCode}]. description=[${event.nativeEvent.description}]`,
+              ),
+              'WebViewHttpError',
+            );
+          }}
+        />
       </View>
       <View style={styles.textInputContainer}>
         <Input
@@ -96,6 +96,9 @@ const Screen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  errorContainer: {
+    flex: 2,
   },
   webviewContainer: {
     flex: 6,

--- a/ErrorHandling/src/screens/ErrorInWebView.tsx
+++ b/ErrorHandling/src/screens/ErrorInWebView.tsx
@@ -16,8 +16,8 @@ const Screen = () => {
   const [host, setHost] = useState<string>(baseHost);
   const [statusCodeInputValue, setStatusCodeInputValue] = useState<string>();
   const [ipInputValue, setIpInputValue] = useState<string>();
-  const [httpError, setHttpError] = useState<WebViewHttpError | undefined>(undefined);
-  const [error, setError] = useState<WebViewError | undefined>(undefined);
+  const [httpError, setHttpError] = useState<WebViewHttpError>();
+  const [error, setError] = useState<WebViewError>();
 
   return (
     <View style={styles.container}>

--- a/ErrorHandling/src/screens/ErrorInWebView.tsx
+++ b/ErrorHandling/src/screens/ErrorInWebView.tsx
@@ -6,14 +6,14 @@ import WebView from 'react-native-webview';
 import {WebViewError, WebViewHttpError} from 'react-native-webview/lib/WebViewTypes';
 
 const baseHost = Platform.select({
-  ios: 'localhost',
+  default: 'localhost',
   android: '10.0.2.2',
 });
 
 const ScreenName = 'ErrorInWebView';
 const Screen = () => {
   const [statusCode, setStatusCode] = useState<string>('200');
-  const [host, setHost] = useState<string>(baseHost ?? 'localhost');
+  const [host, setHost] = useState<string>(baseHost);
   const [statusCodeInputValue, setStatusCodeInputValue] = useState<string>();
   const [ipInputValue, setIpInputValue] = useState<string>();
   const [httpError, setHttpError] = useState<WebViewHttpError | undefined>(undefined);
@@ -84,7 +84,7 @@ const Screen = () => {
             setHttpError(undefined);
             setError(undefined);
             setStatusCode(statusCodeInputValue ?? '200');
-            setHost(ipInputValue ?? baseHost ?? 'localhost');
+            setHost(ipInputValue ?? baseHost);
           }}
           title="WebView再表示"
         />


### PR DESCRIPTION
## ✅ What's done

- [x] WebViewで発生するエラーをハンドリングする方法の検証
- [x] WebViewのタイムアウトを検証 
- [x] READMEに検証内容を追記
- [x] WebViewで表示用にHTTP Serverを追加

## Tests

- [x] 200系のステータスコードが返却される場合
- [x] 400系のステータスコードが返却される場合
- [x] 500系のステータスコードが返却される場合
- [x] HTTP Serverが落ちてる場合

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 4a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし